### PR TITLE
Use path-browserify for web environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1603,6 +1603,11 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "deep-eql": "^4.0.0",
     "fs-extra": "^3.0.1",
     "get-uri": "^2.0.3",
+    "path-browserify": "1.0.1",
     "urijs": "^1.19.1",
     "validator": "^9.4.1",
     "xml2js": "^0.4.19",

--- a/src/jsonschema/jsonSchemaFile.js
+++ b/src/jsonschema/jsonSchemaFile.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFile');
 
-const path = require('path');
+const path = (process && typeof process.platform === 'string') ? require('path') : require('path-browserify');
 const URI = require('urijs');
 const clone = require('clone');
 const deepEql = require('deep-eql');

--- a/src/jsonschema/jsonSchemaFileDraft04.js
+++ b/src/jsonschema/jsonSchemaFileDraft04.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFileDraft04');
 
-const path = require('path');
+const path = (process && typeof process.platform === 'string') ? require('path') : require('path-browserify');
 const URI = require('urijs');
 const JsonSchemaFile = require('./jsonSchemaFile');
 const JsonSchemaSerializerDraft04 = require('./jsonSchemaSerializerDraft04');

--- a/src/jsonschema/jsonSchemaFileDraft06.js
+++ b/src/jsonschema/jsonSchemaFileDraft06.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFileDraft06');
 
-const path = require('path');
+const path = (process && typeof process.platform === 'string') ? require('path') : require('path-browserify');
 const URI = require('urijs');
 const JsonSchemaFileDraft04 = require('./jsonSchemaFileDraft04');
 const JsonSchemaSerializerDraft06 = require('./jsonSchemaSerializerDraft06');

--- a/src/jsonschema/jsonSchemaFileDraft07.js
+++ b/src/jsonschema/jsonSchemaFileDraft07.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFileDraft07');
 
-const path = require('path');
+const path = (process && typeof process.platform === 'string') ? require('path') : require('path-browserify');
 const URI = require('urijs');
 const JsonSchemaFileDraft06 = require('./jsonSchemaFileDraft06');
 


### PR DESCRIPTION
This PR adds support for using `path-browserify` for environments where native `path` is not present (i.e. on web environments)