### PR TITLE
Solve issue exclusiveMinimum

### DIFF
--- a/src/builtInTypeConverter.js
+++ b/src/builtInTypeConverter.js
@@ -555,7 +555,7 @@ class BuiltInTypeConverter {
     jsonSchema.type = JSON_SCHEMA_TYPES.INTEGER;
     jsonSchema.minimum = 0;
     jsonSchema.maximum = 4294967295;
-    jsonSchema.exclusiveMinimum = true;
+    jsonSchema.exclusiveMinimum = -1;
     return true;
   }
 

--- a/xsd2jsonschemafaker.js
+++ b/xsd2jsonschemafaker.js
@@ -16511,7 +16511,7 @@ class BuiltInTypeConverter {
     jsonSchema.type = JSON_SCHEMA_TYPES.INTEGER;
     jsonSchema.minimum = 0;
     jsonSchema.maximum = 4294967295;
-    jsonSchema.exclusiveMinimum = true;
+    jsonSchema.exclusiveMinimum = -1;
     return true;
   }
 


### PR DESCRIPTION
Solve issue to support   <xs:element name="quantity" type="xs:positiveInteger"/>

currently the library is throwing error 'true must be a number'

according to the spec:

Ranges of numbers are specified using a combination of the minimum and maximum keywords, (or exclusiveMinimum and exclusiveMaximum for expressing exclusive range).

If x is the value being validated, the following must hold true:

x ≥ minimum
x > exclusiveMinimum
x ≤ maximum
x < exclusiveMaximum
While you can specify both of minimum and exclusiveMinimum or both of maximum and exclusiveMaximum, it doesn’t really make sense to do so.

{
  "type": "number",
  "minimum": 0,
  "exclusiveMaximum": 100
}



https://json-schema.org/understanding-json-schema/reference/numeric.html#range